### PR TITLE
Implement sign benchmarks

### DIFF
--- a/ubirch/crypto_test.go
+++ b/ubirch/crypto_test.go
@@ -32,8 +32,8 @@ func TestSetKey(t *testing.T) {
 		Keystore: &keystore.Keystore{},
 		Names:    map[string]uuid.UUID{},
 	}
-	id := uuid.MustParse(testUUID)
-	privBytesCorrect, err := hex.DecodeString(testPriv)
+	id := uuid.MustParse(defaultUUID)
+	privBytesCorrect, err := hex.DecodeString(defaultPriv)
 	if err != nil {
 		panic(err)
 	}
@@ -41,15 +41,15 @@ func TestSetKey(t *testing.T) {
 	privBytesTooShort := privBytesCorrect[1:]
 
 	//Test valid key length
-	err = context.SetKey(testName, id, privBytesCorrect)
+	err = context.SetKey(defaultName, id, privBytesCorrect)
 	if err != nil {
 		t.Errorf("SetKey() failed with error: %v", err)
 	}
-	err = context.SetKey(testName, id, privBytesTooShort)
+	err = context.SetKey(defaultName, id, privBytesTooShort)
 	if err == nil {
 		t.Errorf("SetKey() accepts too short keys.")
 	}
-	err = context.SetKey(testName, id, privBytesTooLong)
+	err = context.SetKey(defaultName, id, privBytesTooLong)
 	if err == nil {
 		t.Errorf("SetKey() accepts too long keys")
 	}
@@ -61,8 +61,8 @@ func TestSetPublicKey(t *testing.T) {
 		Keystore: &keystore.Keystore{},
 		Names:    map[string]uuid.UUID{},
 	}
-	id := uuid.MustParse(testUUID)
-	pubBytesCorrect, err := hex.DecodeString(testPub)
+	id := uuid.MustParse(defaultUUID)
+	pubBytesCorrect, err := hex.DecodeString(defaultPub)
 	if err != nil {
 		panic(err)
 	}
@@ -70,15 +70,15 @@ func TestSetPublicKey(t *testing.T) {
 	pubBytesTooShort := pubBytesCorrect[1:]
 
 	//Test valid key length
-	err = context.SetPublicKey(testName, id, pubBytesCorrect)
+	err = context.SetPublicKey(defaultName, id, pubBytesCorrect)
 	if err != nil {
 		t.Errorf("SetPublicKey() failed with error: %v", err)
 	}
-	err = context.SetPublicKey(testName, id, pubBytesTooShort)
+	err = context.SetPublicKey(defaultName, id, pubBytesTooShort)
 	if err == nil {
 		t.Errorf("SetPublicKey() accepts too short keys.")
 	}
-	err = context.SetPublicKey(testName, id, pubBytesTooLong)
+	err = context.SetPublicKey(defaultName, id, pubBytesTooLong)
 	if err == nil {
 		t.Errorf("SetPublicKey() accepts too long keys")
 	}

--- a/ubirch/test_benchmark_common_test.go
+++ b/ubirch/test_benchmark_common_test.go
@@ -81,17 +81,17 @@ func setProtocolContext(p *Protocol, Name string, UUID string, PrivKey string, L
 	//Set private key (public key will automatically be calculated and set)
 	privBytes, err := hex.DecodeString(PrivKey)
 	if err != nil {
-		panic(err)
+		log.Fatalf("setProtocolContext: Error decoding private key string: : %v, string was: %v", err, PrivKey)
 	}
 	err = p.Crypto.SetKey(Name, id, privBytes)
 	if err != nil {
-		panic(err)
+		log.Fatalf("setProtocolContext: Error setting private key bytes: : %v,", err)
 	}
 
 	//Set last Signature
 	lastSigBytes, err := hex.DecodeString(LastSignature)
 	if err != nil {
-		panic(err)
+		log.Fatalf("setProtocolContext: Error decoding last signature string: : %v, string was: %v", err, LastSignature)
 	}
 	p.Signatures[id] = lastSigBytes
 

--- a/ubirch/test_benchmark_common_test.go
+++ b/ubirch/test_benchmark_common_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019 ubirch GmbH.
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+//This file contains common test and benchmark functions as well as defaults
+package ubirch
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	"github.com/google/uuid"
+)
+
+////Default Values////
+// (for consistent defaults in benchmark/test table entries )
+const (
+	defaultName     = "A"
+	defaultUUID     = "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"                                                                                             //"f9038b4b-d3bc-47c9-9968-ea275f1b6de8"
+	defaultPriv     = "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"                                                                 //"10a0bef246575ea219e15bffbb6704d2a58b0e4aa99f101f12f0b1ce7a143559"
+	defaultPub      = "55f0feac4f2bcf879330eff348422ab3abf5237a24acaf0aef3bb876045c4e532fbd6cd8e265f6cf28b46e7e4512cd06ba84bcd3300efdadf28750f43dafd771" //"92bbd65d59aecbdf7b497fb4dcbdffa22833613868ddf35b44f5bd672496664a2cc1d228550ae36a1d0210a3b42620b634dc5d22ecde9e12f37d66eeedee3e6a"
+	defaultLastSig  = "c03821e1bbabebce351044168c5016187829bcf60988869f4d0bd3e8a905d38fa0bde9269042ad062262dd6829cc8def9e71e10d0a527671ca5707a436b1f209"
+	defaultDataSize = 200
+)
+
+//////Helper Functions//////
+
+//loads a protocol context from a json file
+func loadProtocolContext(p *Protocol, filename string) error {
+	contextBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(contextBytes, p)
+	if err != nil {
+		log.Fatalf("unable to deserialize context: %v", err)
+		return err
+	}
+
+	log.Printf("loaded protocol context")
+
+	return nil
+
+}
+
+//saves a protocol context to a json file
+func saveProtocolContext(p *Protocol, filename string) error {
+	contextBytes, _ := json.Marshal(p)
+	err := ioutil.WriteFile(filename, contextBytes, 0666)
+	if err != nil {
+		log.Printf("unable to store protocol context: %v", err)
+		return err
+	}
+
+	log.Printf("saved protocol context")
+	return nil
+
+}
+
+//Sets the passed protocol context to the passed values (name, UUID, private Key, last signature), passed as hex strings
+func setProtocolContext(p *Protocol, Name string, UUID string, PrivKey string, LastSignature string) {
+
+	id := uuid.MustParse(UUID)
+
+	//Set private key (public key will automatically be calculated and set)
+	privBytes, err := hex.DecodeString(PrivKey)
+	if err != nil {
+		panic(err)
+	}
+	err = p.Crypto.SetKey(Name, id, privBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	//Set last Signature
+	lastSigBytes, err := hex.DecodeString(LastSignature)
+	if err != nil {
+		panic(err)
+	}
+	p.Signatures[id] = lastSigBytes
+
+}
+
+//Generates reproducible pseudorandom data using a simple linear congruental generator.
+//NEVER us this for something other than generating bogus input data.
+func deterministicPseudoRandomBytes(seed int32, size int) []byte {
+	block := make([]byte, size)
+	//We use the same parameters used in the "simple" version of glibc's rand()
+	//and simply fill the block with the generated numbers.
+	for index := range block {
+		seed = (1103515245*seed + 12345) & 0x7fffffff
+		block[index] = byte(seed)
+	}
+	return block
+}

--- a/ubirch/ubirch_protocol_benchmark_test.go
+++ b/ubirch/ubirch_protocol_benchmark_test.go
@@ -1,0 +1,138 @@
+package ubirch
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/paypal/go.crypto/keystore"
+)
+
+////Default Values////
+// (for consistent defaults in benchmark table entries )
+const (
+	defaultName     = "A"
+	defaultUUID     = "f9038b4b-d3bc-47c9-9968-ea275f1b6de8"
+	defaultPriv     = "10a0bef246575ea219e15bffbb6704d2a58b0e4aa99f101f12f0b1ce7a143559"
+	defaultPub      = "92bbd65d59aecbdf7b497fb4dcbdffa22833613868ddf35b44f5bd672496664a2cc1d228550ae36a1d0210a3b42620b634dc5d22ecde9e12f37d66eeedee3e6a"
+	defaultLastSig  = "c03821e1bbabebce351044168c5016187829bcf60988869f4d0bd3e8a905d38fa0bde9269042ad062262dd6829cc8def9e71e10d0a527671ca5707a436b1f209"
+	defaultDataSize = 200
+)
+
+//////Helper Functions//////
+
+//loads a protocol context from a json file
+func loadProtocolContext(p *Protocol, filename string) error {
+	contextBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(contextBytes, p)
+	if err != nil {
+		log.Fatalf("unable to deserialize context: %v", err)
+		return err
+	}
+
+	log.Printf("loaded protocol context")
+
+	return nil
+
+}
+
+//saves a protocol context from a json file
+func saveProtocolContext(p *Protocol, filename string) error {
+	contextBytes, _ := json.Marshal(p)
+	err := ioutil.WriteFile(filename, contextBytes, 0666)
+	if err != nil {
+		log.Printf("unable to store protocol context: %v", err)
+		return err
+	}
+
+	log.Printf("saved protocol context")
+	return nil
+
+}
+
+//Sets the passed protocol context to the passed values (name, UUID, private Key, last signature), passed as hex strings
+func setProtocolContext(p *Protocol, Name string, UUID string, PrivKey string, LastSignature string) {
+
+	id := uuid.MustParse(UUID)
+
+	//Set private key (public key will automatically be calculated and set)
+	privBytes, err := hex.DecodeString(PrivKey)
+	if err != nil {
+		panic(err)
+	}
+	err = p.Crypto.SetKey(Name, id, privBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	//Set last Signature
+	lastSigBytes, err := hex.DecodeString(LastSignature)
+	if err != nil {
+		panic(err)
+	}
+	p.Signatures[id] = lastSigBytes
+
+}
+
+//Generates reproducible pseudorandom data using a simple linear congruental generator.
+//NEVER us this for something other than generating bogus input data.
+func deterministicPseudoRandomBytes(seed int32, size int) []byte {
+	block := make([]byte, size)
+	//We use the same parameters used in the "simple" version of glibc's rand()
+	//and simply fill the block with the generated numbers.
+	for index := range block {
+		seed = (1103515245*seed + 12345) & 0x7fffffff
+		block[index] = byte(seed)
+	}
+	return block
+}
+
+//////Benchmark Functions//////
+
+func BenchmarkSign(b *testing.B) {
+	//Define data for all benchmarks to run
+	benchmarks := []struct {
+		testDescription  string
+		deviceName       string
+		deviceUUID       string
+		devicePrivateKey string
+		deviceLastSig    string
+		dataSizeBytes    int
+		signProtocol     ProtocolType
+	}{
+		{"Plain-defaultSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, defaultDataSize, Plain},
+		{"Signed-defaultSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, defaultDataSize, Signed},
+		{"Chained-defaultSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, defaultDataSize, Chained},
+		{"Chained-1KBSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, 1024, Chained},
+		{"Chained-100KBSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, 100 * 1024, Chained},
+		{"Chained-1MBSize", defaultName, defaultUUID, defaultPriv, defaultLastSig, 1024 * 1024, Chained},
+	}
+
+	//Iterate over all benchmarks
+	for _, bm := range benchmarks {
+		//Create new crypto context
+		context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+		p := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
+		//Load reference data into context
+		setProtocolContext(p, bm.deviceName, bm.deviceUUID, bm.devicePrivateKey, bm.deviceLastSig)
+		//Generate pseudrandom input data
+		inputData := deterministicPseudoRandomBytes(0, bm.dataSizeBytes)
+		//Run the current benchmark
+		b.Run(bm.testDescription, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				encoded, err := p.Sign(bm.deviceName, inputData, bm.signProtocol)
+				if err != nil {
+					b.Fatalf("Sign() failed with error %v", err)
+				}
+				_ = encoded
+			}
+		})
+	}
+}

--- a/ubirch/ubirch_protocol_benchmark_test.go
+++ b/ubirch/ubirch_protocol_benchmark_test.go
@@ -1,101 +1,29 @@
+/*
+ * Copyright (c) 2019 ubirch GmbH.
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
 package ubirch
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/paypal/go.crypto/keystore"
 )
-
-////Default Values////
-// (for consistent defaults in benchmark table entries )
-const (
-	defaultName     = "A"
-	defaultUUID     = "f9038b4b-d3bc-47c9-9968-ea275f1b6de8"
-	defaultPriv     = "10a0bef246575ea219e15bffbb6704d2a58b0e4aa99f101f12f0b1ce7a143559"
-	defaultPub      = "92bbd65d59aecbdf7b497fb4dcbdffa22833613868ddf35b44f5bd672496664a2cc1d228550ae36a1d0210a3b42620b634dc5d22ecde9e12f37d66eeedee3e6a"
-	defaultLastSig  = "c03821e1bbabebce351044168c5016187829bcf60988869f4d0bd3e8a905d38fa0bde9269042ad062262dd6829cc8def9e71e10d0a527671ca5707a436b1f209"
-	defaultDataSize = 200
-)
-
-//////Helper Functions//////
-
-//loads a protocol context from a json file
-func loadProtocolContext(p *Protocol, filename string) error {
-	contextBytes, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(contextBytes, p)
-	if err != nil {
-		log.Fatalf("unable to deserialize context: %v", err)
-		return err
-	}
-
-	log.Printf("loaded protocol context")
-
-	return nil
-
-}
-
-//saves a protocol context from a json file
-func saveProtocolContext(p *Protocol, filename string) error {
-	contextBytes, _ := json.Marshal(p)
-	err := ioutil.WriteFile(filename, contextBytes, 0666)
-	if err != nil {
-		log.Printf("unable to store protocol context: %v", err)
-		return err
-	}
-
-	log.Printf("saved protocol context")
-	return nil
-
-}
-
-//Sets the passed protocol context to the passed values (name, UUID, private Key, last signature), passed as hex strings
-func setProtocolContext(p *Protocol, Name string, UUID string, PrivKey string, LastSignature string) {
-
-	id := uuid.MustParse(UUID)
-
-	//Set private key (public key will automatically be calculated and set)
-	privBytes, err := hex.DecodeString(PrivKey)
-	if err != nil {
-		panic(err)
-	}
-	err = p.Crypto.SetKey(Name, id, privBytes)
-	if err != nil {
-		panic(err)
-	}
-
-	//Set last Signature
-	lastSigBytes, err := hex.DecodeString(LastSignature)
-	if err != nil {
-		panic(err)
-	}
-	p.Signatures[id] = lastSigBytes
-
-}
-
-//Generates reproducible pseudorandom data using a simple linear congruental generator.
-//NEVER us this for something other than generating bogus input data.
-func deterministicPseudoRandomBytes(seed int32, size int) []byte {
-	block := make([]byte, size)
-	//We use the same parameters used in the "simple" version of glibc's rand()
-	//and simply fill the block with the generated numbers.
-	for index := range block {
-		seed = (1103515245*seed + 12345) & 0x7fffffff
-		block[index] = byte(seed)
-	}
-	return block
-}
-
-//////Benchmark Functions//////
 
 //BenchmarkSign benchmarks only UPP creation via Protocol.Sign() (NOT Crypto.Sign()) with various payload sizes
 func BenchmarkSign(b *testing.B) {
@@ -142,7 +70,7 @@ func BenchmarkSign(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				encoded, err := p.Sign(bm.deviceName, inputData, bm.signProtocol)
 				if err != nil {
-					b.Fatalf("Sign() failed with error %v", err)
+					b.Fatalf("Protocol.Sign() failed with error %v", err)
 				}
 				_ = encoded
 			}
@@ -189,7 +117,7 @@ func BenchmarkHashUserDataAndSign(b *testing.B) {
 				hash := sha256.Sum256(inputData)
 				encoded, err := p.Sign(bm.deviceName, hash[:], bm.signProtocol)
 				if err != nil {
-					b.Fatalf("Sign() failed with error %v", err)
+					b.Fatalf("Protocol.Sign() failed with error %v", err)
 				}
 				_ = encoded
 			}

--- a/ubirch/ubirch_protocol_test.go
+++ b/ubirch/ubirch_protocol_test.go
@@ -33,59 +33,6 @@ import (
 	"github.com/paypal/go.crypto/keystore"
 )
 
-// test fixtures
-const (
-	testName = "A"
-	testUUID = "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"
-	testPriv = "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"
-	testPub  = "55f0feac4f2bcf879330eff348422ab3abf5237a24acaf0aef3bb876045c4e532fbd6cd8e265f6cf28b46e7e4512cd06ba84bcd3300efdadf28750f43dafd771"
-
-	// expected messages
-	expectedSigned = "9522c4106eac4d0b16e645088c4622e7451ea5a100c4206b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4bc440"
-)
-
-// expected sequence of chained messages (contained signatures are placeholders only, ecdsa is not deterministic)
-var expectedChained = [...]string{
-	"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c4204bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459ac440",
-	"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986c440",
-	"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5c440",
-}
-
-var context = &CryptoContext{
-	Keystore: &keystore.Keystore{},
-	Names:    map[string]uuid.UUID{},
-}
-
-var protocol = Protocol{
-	Crypto:     context,
-	Signatures: map[uuid.UUID][]byte{},
-}
-
-func (c *CryptoContext) GetLastSignature() ([]byte, error) {
-	return nil, nil
-}
-
-func bytesToPrivateKey(bytes []byte) *ecdsa.PrivateKey {
-	priv := new(ecdsa.PrivateKey)
-	priv.D = new(big.Int)
-	priv.D.SetBytes(bytes)
-	priv.PublicKey.Curve = elliptic.P256()
-	priv.PublicKey.X, priv.PublicKey.Y = priv.PublicKey.Curve.ScalarBaseMult(priv.D.Bytes())
-	return priv
-}
-
-func init() {
-	id := uuid.MustParse(testUUID)
-	privBytes, err := hex.DecodeString(testPriv)
-	if err != nil {
-		panic(err)
-	}
-	err = context.storePrivateKey(testName, id, bytesToPrivateKey(privBytes))
-	if err != nil {
-		panic(err)
-	}
-}
-
 func TestDecodeArrayToStruct(t *testing.T) {
 	upp, _ := hex.DecodeString("9623c4104f6b64a7a5c9483786c00d32bc8e03c0c440936a6658ac8c83421c455088f744a5c6f6634ef6e442784da0d6c3f2666b33b3a80a1fb027ebbd07dbc2498ddb614e7dd1e3d0b4c515a4293efa6c6cd42857ca00c4208eac931f0b8e3ace01d901c75511ebc1f63fe66ab4c1dc2c9977897c378c021dc440bfdd69f9cb951f47b8455732404aefbae71662c0ab425986d8afbfbaeb128f63521486c04a258da8150f318c752899b7cae3cd9de67080d0636b8b07dcd286bd")
 	o, err := Decode(upp)
@@ -104,8 +51,18 @@ func TestDecodeArrayToStruct(t *testing.T) {
 }
 
 func TestCreateSignedMessage(t *testing.T) {
+	privateKey := "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"
+	deviceUUID := "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"
+	expectedSigned := "9522c4106eac4d0b16e645088c4622e7451ea5a100c4206b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4bc440"
+
+	//Create new crypto context
+	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
+	//Load reference data into context
+	setProtocolContext(protocol, defaultName, deviceUUID, privateKey, defaultLastSig)
+
 	digest := sha256.Sum256([]byte{'1'})
-	upp, err := protocol.Sign(testName, digest[:], Signed)
+	upp, err := protocol.Sign(defaultName, digest[:], Signed)
 	if err != nil {
 		t.Errorf("signing failed: %v", err)
 	}
@@ -117,10 +74,26 @@ func TestCreateSignedMessage(t *testing.T) {
 }
 
 func TestCreateChainedMessage(t *testing.T) {
+	privateKey := "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"
+	deviceUUID := "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"
+	lastSignature := "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	// expected sequence of chained messages (contained signatures are placeholders only, ecdsa is not deterministic)
+	var expectedChained = [...]string{
+		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c4204bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459ac440",
+		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986c440",
+		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5c440",
+	}
+
+	//Create new crypto context
+	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
+	//Load reference data into context
+	setProtocolContext(protocol, defaultName, deviceUUID, privateKey, lastSignature)
+
 	previousSignature := make([]byte, 64)
 	for i := 0; i < 3; i++ {
 		digest := sha256.Sum256([]byte{byte(i + 1)})
-		upp, err := protocol.Sign(testName, digest[:], Chained)
+		upp, err := protocol.Sign(defaultName, digest[:], Chained)
 		if err != nil {
 			t.Errorf("signing failed: %v", err)
 		}

--- a/ubirch/ubirch_protocol_test.go
+++ b/ubirch/ubirch_protocol_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"log"
 	"math/big"
 	"testing"
 
@@ -33,83 +32,201 @@ import (
 	"github.com/paypal/go.crypto/keystore"
 )
 
+//TestDecodeArrayToStruct decodes a 'Chained' type UPP and checks expected UUID
+// and payload/hash data (currently no signature verification tests)
 func TestDecodeArrayToStruct(t *testing.T) {
-	upp, _ := hex.DecodeString("9623c4104f6b64a7a5c9483786c00d32bc8e03c0c440936a6658ac8c83421c455088f744a5c6f6634ef6e442784da0d6c3f2666b33b3a80a1fb027ebbd07dbc2498ddb614e7dd1e3d0b4c515a4293efa6c6cd42857ca00c4208eac931f0b8e3ace01d901c75511ebc1f63fe66ab4c1dc2c9977897c378c021dc440bfdd69f9cb951f47b8455732404aefbae71662c0ab425986d8afbfbaeb128f63521486c04a258da8150f318c752899b7cae3cd9de67080d0636b8b07dcd286bd")
-	o, err := Decode(upp)
-	if err != nil {
-		t.Errorf("upp can't be decoded: %v", err)
+
+	var tests = []struct {
+		testName        string
+		inputUPP        string
+		expectedUUID    string
+		expectedPayload string
+	}{
+		{
+			"ChainedUPP-32BytesPayload-Packet1",
+			"9623c4106eac4d0b16e645088c4622e7451ea5a1c440855d94b0ec9c7bcd21149f2044f8f93a6d83dea968ed96c18e02c11c2fe3a04e75a84f3d73adaeb1a0b975e70c5d21a22fb0db8ea6473516210b01404862e92400c420397edf2cf58afb187156d7c4ade27330a92ecf5c653aeb48e106c7f41d926360c440c3456908c392342f34df464f48fc7a44fe2e93d56f097b173629d4d891b1c8542a5237fe2c69310d4462adcb642d4da44ca84629dfa980805057e0642069c96b",
+			"6eac4d0b-16e6-4508-8c46-22e7451ea5a1",
+			"397edf2cf58afb187156d7c4ade27330a92ecf5c653aeb48e106c7f41d926360",
+		},
+		{
+			"ChainedUPP-32BytesPayload-Packet2",
+			"9623c4106eac4d0b16e645088c4622e7451ea5a1c4406beb37362b68e6afe66eb33b7ed8d2a5a059e6ca4f627923faa35d2ded50e69a75733b8f006ac8198b67e22ae0489d8d314b16cf59f60f4cb060b84d398d8c8700c4201bb891f6f764cd8293d0c9ceeffc85da0be801a6e7943d328300397edf2cf58ac440c436a0e8ca003d849e1e3a8ca756cf56d6a0599f399f58d8cdbee813ce340cd3bd27ec509b15d5dffeef6b2792f666cf4ecbe8a8e5c58806983fef7ecbaa7182",
+			"6eac4d0b-16e6-4508-8c46-22e7451ea5a1",
+			"1bb891f6f764cd8293d0c9ceeffc85da0be801a6e7943d328300397edf2cf58a",
+		},
 	}
 
-	c := o.(*ChainedUPP)
-	if uuid.MustParse("4f6b64a7-a5c9-4837-86c0-0d32bc8e03c0") != c.Uuid {
-		t.Errorf("uuid does not match")
-	}
-	hash, _ := base64.StdEncoding.DecodeString("lmjNczf0vBzd+pi6WL9eWllxZ4ate8Ju0uOxWx83SjA=")
-	if bytes.Compare(hash, c.Payload) == 0 {
-		t.Errorf("hash does not match")
+	//Iterate over all tests
+	for _, currTest := range tests {
+		t.Run(currTest.testName, func(t *testing.T) {
+			//Try to decode chained UPP
+			bytesUPP, err := hex.DecodeString(currTest.inputUPP)
+			if err != nil {
+				t.Fatalf("Error decoding expected input UPP string: %v, string was: %v", err, currTest.inputUPP)
+			}
+			o, err := Decode(bytesUPP)
+			if err != nil {
+				t.Errorf("upp can't be decoded: %v", err)
+			}
+			//Create/cast chained UPP data
+			c := o.(*ChainedUPP) //TODO:extend test for other UPP types than 'chained'
+			//Check decoded UUID
+			if uuid.MustParse(currTest.expectedUUID) != c.Uuid {
+				t.Errorf("uuid does not match:\nexpected: %v\ngot:      %v", currTest.expectedUUID, c.Uuid)
+			}
+			//Check decoded payload/hash
+			expectedPayloadBytes, err := hex.DecodeString(currTest.expectedPayload)
+			if err != nil {
+				t.Fatalf("Error decoding expected payload string: %v, string was: %v", err, currTest.expectedPayload)
+			}
+			if !(bytes.Equal(expectedPayloadBytes, c.Payload)) {
+				t.Errorf("Decoded hash/payload does not match:\nexpected: %x\ngot:      %x", expectedPayloadBytes, c.Payload)
+			}
+		})
 	}
 }
 
+//TestCreateSignedMessage tests 'Signed' type UPP creation from given user data. Data is hashed, hash is
+//used as UPP payload and then the created encoded UPP data (without the signature, as its
+//non-deterministic) is compared to the expected values
 func TestCreateSignedMessage(t *testing.T) {
-	privateKey := "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"
-	deviceUUID := "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"
-	expectedSigned := "9522c4106eac4d0b16e645088c4622e7451ea5a100c4206b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4bc440"
-
-	//Create new crypto context
-	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
-	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
-	//Load reference data into context
-	setProtocolContext(protocol, defaultName, deviceUUID, privateKey, defaultLastSig)
-
-	digest := sha256.Sum256([]byte{'1'})
-	upp, err := protocol.Sign(defaultName, digest[:], Signed)
-	if err != nil {
-		t.Errorf("signing failed: %v", err)
+	var tests = []struct {
+		testName               string
+		privateKey             string
+		deviceUUID             string
+		dataToHash             string
+		expectedUPPNoSignature string
+	}{
+		{
+			"Data='1'",
+			"6f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937",
+			"6eac4d0b-16e6-4508-8c46-22e7451ea5a1",
+			"31", //equals the character "1" string
+			"9522c4106eac4d0b16e645088c4622e7451ea5a100c4206b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4bc440",
+		},
+		{
+			"Data='Hello World!'",
+			"6f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937",
+			"6eac4d0b-16e6-4508-8c46-22e7451ea5a1",
+			"48656c6c6f20576f726c6421", //"Hello World!"
+			"9522c4106eac4d0b16e645088c4622e7451ea5a100c4207f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069c440",
+		},
 	}
-	log.Printf("E: %s", expectedSigned)
-	log.Printf("R: %s", hex.EncodeToString(upp[:len(upp)-64]))
-	if expectedSigned != hex.EncodeToString(upp[:len(upp)-64]) {
-		t.Errorf("upp encoding wrong")
+
+	//Iterate over all tests
+	for _, currTest := range tests {
+		t.Run(currTest.testName, func(t *testing.T) {
+			//Create new crypto context
+			context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+			protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
+			//Load reference data into context
+			setProtocolContext(protocol, defaultName, currTest.deviceUUID, currTest.privateKey, defaultLastSig)
+			//Create hash of input data
+			dataToHashBytes, err := hex.DecodeString(currTest.dataToHash)
+			if err != nil {
+				t.Fatalf("Error decoding input data string: %v, string was: %v", err, currTest.dataToHash)
+			}
+			hash := sha256.Sum256(dataToHashBytes)
+			//Create 'Signed' type UPP packet
+			upp, err := protocol.Sign(defaultName, hash[:], Signed)
+			if err != nil {
+				t.Errorf("signing failed: %v", err)
+			}
+			//Check created UPP (without signature at the end, as it's non-deterministic)
+			expectedUPPBytesNoSignature, err := hex.DecodeString(currTest.expectedUPPNoSignature)
+			if err != nil {
+				t.Fatalf("Error decoding UPP data string: %v, string was: %v", err, currTest.expectedUPPNoSignature)
+			}
+			UPPBytesNoSignature := (upp[:len(upp)-64])
+			if !(bytes.Equal(expectedUPPBytesNoSignature, UPPBytesNoSignature)) {
+				t.Errorf("UPP data comparison (without signature) failed:\nexpected: %x\ngot:      %x", expectedUPPBytesNoSignature, UPPBytesNoSignature)
+			}
+		})
 	}
 }
 
+//TestCreateChainedMessage tests 'Chained' type UPP creation across multiple chained packets. Each input is hashed, hash is
+//used as UPP payload and then the created encoded UPP data (without the signature, as its
+//non-deterministic) is compared to the expected values. During this, the signature of the last UPP is manually copied into the
+//expected data, as ECDSA is non-deterministic, thus only testing if the basic UPP encoding works.
 func TestCreateChainedMessage(t *testing.T) {
-	privateKey := "8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937"
-	deviceUUID := "6eac4d0b-16e6-4508-8c46-22e7451ea5a1"
-	lastSignature := "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	// expected sequence of chained messages (contained signatures are placeholders only, ecdsa is not deterministic)
-	var expectedChained = [...]string{
-		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c4204bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459ac440",
-		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986c440",
-		"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5c440",
+	var tests = []struct {
+		testName                   string
+		privateKey                 string
+		deviceUUID                 string
+		lastSignature              string
+		dataInputs                 []string
+		expectedChainedNoSignature []string
+	}{
+		{
+			"Test1",
+			"8f827f925f83b9e676aeb87d14842109bee64b02f1398c6dcdd970d5d6880937",
+			"6eac4d0b-16e6-4508-8c46-22e7451ea5a1",
+			"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			[]string{
+				"01",
+				"02",
+				"03",
+			},
+			[]string{
+				"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c4204bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459ac440",
+				"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986c440",
+				"9623c4106eac4d0b16e645088c4622e7451ea5a1c4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c420084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5c440",
+			},
+		},
 	}
 
-	//Create new crypto context
-	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
-	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
-	//Load reference data into context
-	setProtocolContext(protocol, defaultName, deviceUUID, privateKey, lastSignature)
+	//Iterate over all tests
+	for _, currTest := range tests {
+		t.Run(currTest.testName, func(t *testing.T) {
+			//Create new crypto context
+			context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+			protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
+			//Load reference data into context
+			setProtocolContext(protocol, defaultName, currTest.deviceUUID, currTest.privateKey, currTest.lastSignature)
+			//Set 'last signature' variable according to test parameters
+			lastSignatureBytes, err := hex.DecodeString(currTest.lastSignature)
+			if err != nil {
+				t.Fatalf("Error decoding input data string: %v, string was: %v", err, currTest.lastSignature)
+			}
+			if len(lastSignatureBytes) != 64 {
+				t.Fatalf("Error: wrong size for last signature, expected 64 bytes but got: %v bytes", len(lastSignatureBytes))
+			}
+			//Loop over input data and expected UPP packets
+			for i := 0; i < len(currTest.dataInputs); i++ {
+				//Load expected UPP data
+				expectedUPPBytesNoSignature, err := hex.DecodeString(currTest.expectedChainedNoSignature[i])
+				if err != nil {
+					t.Fatalf("Error decoding expected data string: %v, string was: %v", err, currTest.expectedChainedNoSignature[i])
+				}
+				//Overwrite 'last signature' field in expected UPP data with signature of last packet
+				copy(expectedUPPBytesNoSignature[22:22+64], lastSignatureBytes)
 
-	previousSignature := make([]byte, 64)
-	for i := 0; i < 3; i++ {
-		digest := sha256.Sum256([]byte{byte(i + 1)})
-		upp, err := protocol.Sign(defaultName, digest[:], Chained)
-		if err != nil {
-			t.Errorf("signing failed: %v", err)
-		}
-		expected, _ := hex.DecodeString(expectedChained[i])
-		copy(expected[22:22+64], previousSignature)
-		previousSignature = upp[len(upp)-64:]
-		//log.Printf("%d S: %s", i, hex.EncodeToString(previousSignature))
-		log.Printf("%d E: (%d) %s", i, len(expected), hex.EncodeToString(expected))
-		log.Printf("%d R: (%d) %s", i, len(upp[:len(upp)-64]), hex.EncodeToString(upp[:len(upp)-64]))
-		if !bytes.Equal(expected, upp[:len(upp)-64]) {
-			t.Errorf("chain: %d: upp encoding wrong", i)
-			return
-		}
+				//Create hash of input data for the payload
+				dataInputBytes, err := hex.DecodeString(currTest.dataInputs[i])
+				if err != nil {
+					t.Fatalf("Error decoding input data string: %v, string was: %v", err, currTest.dataInputs[i])
+				}
+				hash := sha256.Sum256(dataInputBytes)
+				//Create UPP packet with hash as payload
+				upp, err := protocol.Sign(defaultName, hash[:], Chained)
+				if err != nil {
+					t.Errorf("signing failed: %v", err)
+				}
+				//Save signature from newly created UPP for next round
+				lastSignatureBytes = upp[len(upp)-64:]
+
+				//Check if created UPP data is same as expected, not comparing the signature
+				UPPBytesNoSignature := upp[:len(upp)-64]
+				if !bytes.Equal(expectedUPPBytesNoSignature, UPPBytesNoSignature) {
+					t.Errorf("UPP data comparison (without signature) failed:\nexpected: %x\ngot:      %x", expectedUPPBytesNoSignature, UPPBytesNoSignature)
+				}
+			}
+		})
 	}
 }
 
+//TestVerifyHashedMessage in its current state only tests if the ECDSA library behaves as expected
 func TestVerifyHashedMessage(t *testing.T) {
 	vkb, _ := base64.StdEncoding.DecodeString("o71ufIY0rP4GXQELZcXlm6t2s/LB29jzGfmheG3q8dJecxrGc/bqIODYcfROx6ofgunyarvG4lFiP+7p18qZqg==")
 	hsh, _ := base64.StdEncoding.DecodeString("T2v511D0Upfr7Vl0DY5xnganDXlUCILCfZvetExHgzQ=")
@@ -126,9 +243,7 @@ func TestVerifyHashedMessage(t *testing.T) {
 	r.SetBytes(sig[:32])
 	s.SetBytes(sig[32:])
 
-	if ecdsa.Verify(&vk, hsh, r, s) {
-		log.Printf("signature okay")
-	} else {
-		t.Fatalf("signature not okay")
+	if !(ecdsa.Verify(&vk, hsh, r, s)) {
+		t.Errorf("ecdsa.Verify() failed to verify known-good signature")
 	}
 }


### PR DESCRIPTION
Implements benchmarks for UPP creation, both from "user data" (data->hash->payload->UPP) as well as direct UPP creation (data=payload->UPP). Furthermore the previously implemented tests are cleaned up and changed to table-driven and side-effect-free.