### PR TITLE
replace keystore implementation with interface

### DIFF
--- a/ubirch/crypto.go
+++ b/ubirch/crypto.go
@@ -30,43 +30,9 @@ import (
 	"math/big"
 
 	"github.com/google/uuid"
-	"github.com/paypal/go.crypto/keystore"
 )
 
-// Keystorer contains the methods that must be implemented by the keystore
-// implementation.
-type Keystorer interface {
-	GetKey(keyname string) ([]byte, error)
-	SetKey(keyname string, keyvalue []byte) error
-}
-
-type EncryptedKeystore struct {
-	*keystore.Keystore
-	Secret []byte
-}
-
-// Ensure EncryptedKeystore implements the Keystorer interface
-var _ Keystorer = (*EncryptedKeystore)(nil)
-
-// NewEncryptedKeystore returns a new freshly initialized Keystore
-func NewEncryptedKeystore(secret []byte) *EncryptedKeystore {
-	return &EncryptedKeystore{
-		Keystore: &keystore.Keystore{},
-		Secret:   []byte("2234567890123456"),
-	}
-}
-
-// GetKey returns a Key from the Keystore
-func (enc *EncryptedKeystore) GetKey(keyname string) ([]byte, error) {
-	return enc.Keystore.Get(keyname, enc.Secret)
-}
-
-// SetKey sets a key in the Keystore
-func (enc *EncryptedKeystore) SetKey(keyname string, keyvalue []byte) error {
-	return enc.Keystore.Set(keyname, keyvalue, enc.Secret)
-}
-
-// This crypto context contains the key store, a mapping for names -> UUIDs
+// CryptoContext contains the key store, a mapping for names -> UUIDs
 // and the last generated signature per UUID.
 type CryptoContext struct {
 	Keystore Keystorer

--- a/ubirch/crypto.go
+++ b/ubirch/crypto.go
@@ -45,10 +45,23 @@ type EncryptedKeystore struct {
 	Secret []byte
 }
 
+// Ensure EncryptedKeystore implements the Keystorer interface
+var _ Keystorer = (*EncryptedKeystore)(nil)
+
+// NewEncryptedKeystore returns a new freshly initialized Keystore
+func NewEncryptedKeystore(secret []byte) *EncryptedKeystore {
+	return &EncryptedKeystore{
+		Keystore: &keystore.Keystore{},
+		Secret:   []byte("2234567890123456"),
+	}
+}
+
+// GetKey returns a Key from the Keystore
 func (enc *EncryptedKeystore) GetKey(keyname string) ([]byte, error) {
 	return enc.Keystore.Get(keyname, enc.Secret)
 }
 
+// SetKey sets a key in the Keystore
 func (enc *EncryptedKeystore) SetKey(keyname string, keyvalue []byte) error {
 	return enc.Keystore.Set(keyname, keyvalue, enc.Secret)
 }

--- a/ubirch/crypto.go
+++ b/ubirch/crypto.go
@@ -46,6 +46,9 @@ type CryptoContext struct {
 	Names    map[string]uuid.UUID
 }
 
+// Ensure CryptoContext implements the Crypto interface
+var _ Crypto = (*CryptoContext)(nil)
+
 func encodePrivateKey(privateKey *ecdsa.PrivateKey) ([]byte, error) {
 	x509Encoded, err := x509.MarshalECPrivateKey(privateKey)
 	if err != nil {

--- a/ubirch/crypto.go
+++ b/ubirch/crypto.go
@@ -30,13 +30,19 @@ import (
 	"math/big"
 
 	"github.com/google/uuid"
-	"github.com/paypal/go.crypto/keystore"
 )
+
+// Keystorer contains the methods that must be implemented by the keystore
+// implementation.
+type Keystorer interface {
+	Get(keyname string, kek []byte) ([]byte, error)
+	Set(keyname string, keyvalue []byte, kek []byte) error
+}
 
 // This crypto context contains the key store, a mapping for names -> UUIDs
 // and the last generated signature per UUID.
 type CryptoContext struct {
-	Keystore *keystore.Keystore
+	Keystore Keystorer
 	Names    map[string]uuid.UUID
 }
 

--- a/ubirch/crypto_test.go
+++ b/ubirch/crypto_test.go
@@ -39,9 +39,13 @@ import (
 func TestCreateKeystore(t *testing.T) {
 	asserter := assert.New(t)
 	//create new crypto context and check, if the kystore is correct TODO not sure if this test is valid
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var kstore = &EncryptedKeystore{
+		Keystore: &keystore.Keystore{},
+		Secret:   []byte("1234567890123456"),
+	}
+	var context = &CryptoContext{Keystore: kstore, Names: map[string]uuid.UUID{}}
 
-	asserter.IsTypef(&keystore.Keystore{}, context.Keystore, "Keystore creation failed")
+	asserter.IsTypef(kstore, context.Keystore, "Keystore creation failed")
 }
 
 // TODO saveProtocolContext why is this function in the main
@@ -54,7 +58,13 @@ func TestCreateKeystore(t *testing.T) {
 func TestLoadKeystore_SaveKeystore(t *testing.T) {
 	asserter := assert.New(t)
 	//Set up test objects and parameters
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("1234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	p := Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 
 	id := uuid.MustParse(defaultUUID)
@@ -64,7 +74,13 @@ func TestLoadKeystore_SaveKeystore(t *testing.T) {
 	asserter.NotNilf(pubKeyBytesNew, "Public Key for existing Key empty")
 	asserter.NoErrorf(saveProtocolContext(&p, "temp.json"), "Failed Saving protocol context")
 
-	context2 := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	context2 := &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	p2 := Protocol{Crypto: context2, Signatures: map[uuid.UUID][]byte{}}
 	asserter.NoErrorf(loadProtocolContext(&p2, "temp.json"), "Failed loading protocol context")
 	pubKeyBytesLoad, err := p2.GetPublicKey(defaultName)
@@ -85,7 +101,11 @@ func TestCryptoContext_GetUUID(t *testing.T) {
 	)
 	// prepare
 	asserter := assert.New(t)
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var kstore = &EncryptedKeystore{
+		Keystore: &keystore.Keystore{},
+		Secret:   []byte("1234567890123456"),
+	}
+	var context = &CryptoContext{Keystore: kstore, Names: map[string]uuid.UUID{}}
 	p := Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 
 	// test the correct UUID but before loading the context
@@ -113,7 +133,13 @@ func TestCryptoContext_GetUUID(t *testing.T) {
 func TestCryptoContext_SetKey(t *testing.T) {
 	asserter := assert.New(t)
 	//Set up test objects and parameters
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("1234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 
 	id := uuid.MustParse(defaultUUID)
 	privBytesCorrect, err := hex.DecodeString(defaultPriv)
@@ -140,7 +166,13 @@ func TestCryptoContext_SetKey(t *testing.T) {
 func TestCryptoContext_SetPublicKey(t *testing.T) {
 	asserter := assert.New(t)
 	//Set up test objects and parameters
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 
 	id := uuid.MustParse(defaultUUID)
 	pubBytesCorrect, err := hex.DecodeString(defaultPub)
@@ -164,7 +196,13 @@ func TestCryptoContext_SetPublicKey(t *testing.T) {
 //		Generate Key with no uuid
 func TestCryptoContext_GenerateKey_NOTRDY(t *testing.T) {
 	asserter := assert.New(t)
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	p := Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 
 	asserter.NoErrorf(loadProtocolContext(&p, "test.json"), "Failed loading")
@@ -200,7 +238,13 @@ func TestCryptoContext_GetPublicKey(t *testing.T) {
 		unknownName = "NOBODY"
 	)
 	asserter := assert.New(t)
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	p := Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 	// check for non existing key
 	pubKeyBytes, err := p.GetPublicKey(unknownName)
@@ -229,7 +273,13 @@ func TestCryptoContext_GetPrivateKey_NOTRDY(t *testing.T) {
 // TestCryptoContext_GetCSR_NOTRDY the required method is not implemented yet
 func TestCryptoContext_GetCSR_NOTRDY(t *testing.T) {
 	asserter := assert.New(t)
-	var context = &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	var context = &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	p := Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 	certificate, err := p.GetCSR(defaultName)
 	asserter.Nilf(err, "Getting CSR failed")

--- a/ubirch/crypto_test.go
+++ b/ubirch/crypto_test.go
@@ -28,8 +28,9 @@ package ubirch
 
 import (
 	"encoding/hex"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"
 	"github.com/paypal/go.crypto/keystore"
@@ -77,7 +78,7 @@ func TestLoadKeystore_SaveKeystore(t *testing.T) {
 	context2 := &CryptoContext{
 		Keystore: &EncryptedKeystore{
 			Keystore: &keystore.Keystore{},
-			Secret:   []byte("2234567890123456"),
+			Secret:   []byte("1234567890123456"),
 		},
 		Names: map[string]uuid.UUID{},
 	}

--- a/ubirch/keystore.go
+++ b/ubirch/keystore.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019 ubirch GmbH.
+ *
+ * ```
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ```
+ */
+
+package ubirch
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/paypal/go.crypto/keystore"
+)
+
+// Keystorer contains the methods that must be implemented by the keystore
+// implementation.
+type Keystorer interface {
+	GetKey(keyname string) ([]byte, error)
+	SetKey(keyname string, keyvalue []byte) error
+
+	// Required for saving and restoring
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(b []byte) error
+}
+
+// EncryptedKeystore is the reference implementation for a simple keystore.
+type EncryptedKeystore struct {
+	*keystore.Keystore
+	Secret []byte
+}
+
+// Ensure EncryptedKeystore implements the Keystorer interface
+var _ Keystorer = (*EncryptedKeystore)(nil)
+
+// NewEncryptedKeystore returns a new freshly initialized Keystore
+func NewEncryptedKeystore(secret []byte) *EncryptedKeystore {
+	return &EncryptedKeystore{
+		Keystore: &keystore.Keystore{},
+		Secret:   []byte("2234567890123456"),
+	}
+}
+
+// GetKey returns a Key from the Keystore
+func (enc *EncryptedKeystore) GetKey(keyname string) ([]byte, error) {
+	content, err := enc.Keystore.Get(keyname, enc.Secret)
+	if err != nil {
+		// try old format, where the key was derived from the keyname
+		// itself.
+		if content, err := enc.compatDecrypt(keyname); err == nil {
+			return content, nil
+		}
+
+		// if that didnt work, return original error.
+		return nil, err
+	}
+	return content, nil
+}
+
+// SetKey sets a key in the Keystore
+func (enc *EncryptedKeystore) SetKey(keyname string, keyvalue []byte) error {
+	return enc.Keystore.Set(keyname, keyvalue, enc.Secret)
+}
+
+// compatDecrypt is the compatibility to the old version. Originally the
+// kek (key encrypting key) was derived from the UUID.
+func (enc *EncryptedKeystore) compatDecrypt(keyname string) ([]byte, error) {
+	// Public keys were prefixed with an underscore
+	keyname = strings.TrimPrefix(keyname, "_")
+
+	u, err := uuid.Parse(keyname)
+	if err != nil {
+		return nil, err
+	}
+	kek, err := u.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return enc.Keystore.Get(keyname, kek)
+}
+
+// MarshalJSON implements the json.Marshaler interface. The Password will not be
+// marshaled.
+func (enc *EncryptedKeystore) MarshalJSON() ([]byte, error) {
+	return json.Marshal(enc.Keystore)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface. The struct must not be
+// null, and the password will not be read from the json, and needs to be set
+// seperately.
+func (enc *EncryptedKeystore) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, enc.Keystore)
+}

--- a/ubirch/test_benchmark_common_test.go
+++ b/ubirch/test_benchmark_common_test.go
@@ -84,7 +84,13 @@ func deleteProtocolContext(filename string) error {
 
 //Creates a new protocol context for a UPP creator (privkey is passed, pubkey is calculated)
 func newProtocolContextSigner(Name string, UUID string, PrivKey string, LastSignature string) (*Protocol, error) {
-	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	context := &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 	//Load reference data into context
 	err := setProtocolContext(protocol, Name, UUID, PrivKey, "", LastSignature)
@@ -93,7 +99,13 @@ func newProtocolContextSigner(Name string, UUID string, PrivKey string, LastSign
 
 //Creates a new protocol context for a UPP verifier (only pubkey is needed)
 func newProtocolContextVerifier(Name string, UUID string, PubKey string) (*Protocol, error) {
-	context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+	context := &CryptoContext{
+		Keystore: &EncryptedKeystore{
+			Keystore: &keystore.Keystore{},
+			Secret:   []byte("2234567890123456"),
+		},
+		Names: map[string]uuid.UUID{},
+	}
 	protocol := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 	//Load reference data into context
 	err := setProtocolContext(protocol, Name, UUID, "", PubKey, "")

--- a/ubirch/ubirch_protocol_benchmark_test.go
+++ b/ubirch/ubirch_protocol_benchmark_test.go
@@ -68,7 +68,13 @@ func BenchmarkSign(b *testing.B) {
 	//Iterate over all benchmarks
 	for _, bm := range benchmarks {
 		//Create new crypto context
-		context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+		context := &CryptoContext{
+			Keystore: &EncryptedKeystore{
+				Keystore: &keystore.Keystore{},
+				Secret:   []byte("2234567890123456"),
+			},
+			Names: map[string]uuid.UUID{},
+		}
 		p := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 		//Load reference data into context
 		setProtocolContext(p, bm.deviceName, bm.deviceUUID, bm.devicePrivateKey, "", bm.deviceLastSig)
@@ -114,7 +120,13 @@ func BenchmarkHashUserDataAndSign(b *testing.B) {
 	//Iterate over all benchmarks
 	for _, bm := range benchmarks {
 		//Create new crypto context
-		context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+		context := &CryptoContext{
+			Keystore: &EncryptedKeystore{
+				Keystore: &keystore.Keystore{},
+				Secret:   []byte("2234567890123456"),
+			},
+			Names: map[string]uuid.UUID{},
+		}
 		p := &Protocol{Crypto: context, Signatures: map[uuid.UUID][]byte{}}
 		//Load reference data into context
 		setProtocolContext(p, bm.deviceName, bm.deviceUUID, bm.devicePrivateKey, "", bm.deviceLastSig)

--- a/ubirch/ubirch_protocol_test.go
+++ b/ubirch/ubirch_protocol_test.go
@@ -490,7 +490,13 @@ func TestProtocol_Verify(t *testing.T) {
 			requirer := require.New(t)
 
 			// Create new context
-			context := &CryptoContext{Keystore: &keystore.Keystore{}, Names: map[string]uuid.UUID{}}
+			context := &CryptoContext{
+				Keystore: &EncryptedKeystore{
+					Keystore: &keystore.Keystore{},
+					Secret:   []byte("2234567890123456"),
+				},
+				Names: map[string]uuid.UUID{},
+			}
 			protocol := &Protocol{Crypto: context, Signatures: nil}
 
 			// Load reference data into context


### PR DESCRIPTION
This allows users of the ubirch interface to define their own keystore (database, file, etc.) or keep using the paypal-keystore.